### PR TITLE
Enable windows support

### DIFF
--- a/lib/beaker/hypervisor/google_compute.rb
+++ b/lib/beaker/hypervisor/google_compute.rb
@@ -177,10 +177,11 @@ module Beaker
             value: 'FALSE'
           },
         ]
-        next if mdata.empty?
+        unless mdata.empty?
         # Add the metadata to the host
         @gce_helper.set_metadata_on_instance(host['vmhostname'], mdata)
         @logger.debug("Added tags to Google Compute instance #{host.name}: #{host['vmhostname']}")
+        end
 
         host['ip'] = instance.network_interfaces[0].access_configs[0].nat_ip
 

--- a/lib/beaker/hypervisor/google_compute.rb
+++ b/lib/beaker/hypervisor/google_compute.rb
@@ -164,9 +164,9 @@ module Beaker
 
         # Make sure we have a non root/Adminsitor user to log in as
         if host['user'] == "root" || host['user'] == "Administrator" || host['user'].empty?
-          intial_user = 'google_compute'
+          initial_user = 'google_compute'
         else
-          intial_user = host['user']
+          initial_user = host['user']
         end
 
         # add metadata to instance, if there is any to set
@@ -175,7 +175,7 @@ module Beaker
         mdata = [
           {
             key: 'ssh-keys',
-            value: "#{intial_user}:#{File.read(find_google_ssh_public_key).strip}"
+            value: "#{initial_user}:#{File.read(find_google_ssh_public_key).strip}"
           },
           # For now oslogin needs to be disabled as there's no way to log in as root and it would
           # take too much work on beaker to add sudo support to everything
@@ -212,7 +212,7 @@ module Beaker
           @logger.info('Not enabling root ssh as disable_root_ssh is true')
         else
           real_user = host['user']
-          host['user'] = intial_user
+          host['user'] = initial_user
           # Set the ssh private key we need to use
           host.options['ssh']['keys'] = [find_google_ssh_private_key]
 

--- a/lib/beaker/hypervisor/google_compute.rb
+++ b/lib/beaker/hypervisor/google_compute.rb
@@ -164,7 +164,9 @@ module Beaker
 
         # Make sure we have a non root/Adminsitor user to log in as
         if host['user'] == "root" || host['user'] == "Administrator" || host['user'].empty?
-          host['user'] = 'google_compute'
+          intial_user = 'google_compute'
+        else
+          intial_user = host['user']
         end
 
         # add metadata to instance, if there is any to set
@@ -173,7 +175,7 @@ module Beaker
         mdata = [
           {
             key: 'ssh-keys',
-            value: "#{host['user']}:#{File.read(find_google_ssh_public_key).strip}"
+            value: "#{intial_user}:#{File.read(find_google_ssh_public_key).strip}"
           },
           # For now oslogin needs to be disabled as there's no way to log in as root and it would
           # take too much work on beaker to add sudo support to everything
@@ -209,12 +211,14 @@ module Beaker
         if host['disable_root_ssh'] == true
           @logger.info('Not enabling root ssh as disable_root_ssh is true')
         else
+          real_user = host['user']
+          host['user'] = intial_user
           # Set the ssh private key we need to use
           host.options['ssh']['keys'] = [find_google_ssh_private_key]
 
           copy_ssh_to_root(host, @options)
           enable_root_login(host, @options)
-
+          host['user'] = real_user
           # shut down connection, will reconnect on next exec
           host.close
         end


### PR DESCRIPTION
Enable SSH support on windows VMs.

Fix hardcoding the username for connection

Don't skip network configuration if metadata is empty.
Metadata is hardcoded at the moment, so it could never be empty.

Tested and working on current windows 2019 images

Closes #22 